### PR TITLE
Allow link repo with a different CLA(or null CLA) from its org CLA if exists

### DIFF
--- a/src/client/controller/home.js
+++ b/src/client/controller/home.js
@@ -8,9 +8,11 @@
 var isInArray = function (item, items) {
     function check(linkedItem) {
         if (!item.full_name) {
+            // The item is an org
             return linkedItem.org === item.login;
         } else {
-            return (linkedItem.repo === item.name && linkedItem.owner === item.owner.login) || linkedItem.org === item.owner.login;
+            // The item is a repo
+            return linkedItem.repo === item.name && linkedItem.owner === item.owner.login;
         }
     }
     return items.some(check);
@@ -310,7 +312,7 @@ module.controller('HomeCtrl', ['$rootScope', '$scope', '$document', '$HUB', '$RP
             };
 
             $scope.isRepo = function (item) {
-                return item.full_name ? true : false;
+                return item && item.full_name ? true : false;
             };
 
             $scope.addWebhook = function (item) {
@@ -424,6 +426,41 @@ module.controller('HomeCtrl', ['$rootScope', '$scope', '$document', '$HUB', '$RP
                 return item.full_name ? 'Repositories' : 'Organisations';
             };
 
+            var handleNullCla = function (item) {
+                var nullCla = {
+                    name: 'No CLA',
+                    url: null
+                };
+                var clearDropdown = function (item) {
+                    if (item && $scope.isRepo(item)) {
+                        if (!$scope.gists.some(function (cla) {
+                            return cla.name === nullCla.name && cla.url === nullCla.url;
+                        })) {
+                            $scope.gists.push(nullCla);
+                        }
+                    } else {
+                        $scope.gists = $scope.gists.filter(function (cla) {
+                            return cla.name !== nullCla.name && cla.url !== nullCla.url;
+                        });
+                    }
+                };
+                var clearGistSelection = function (item) {
+                    if (!$scope.isRepo(item) && $scope.selected.gist && $scope.selected.gist.name === nullCla.name && $scope.selected.gist.url === nullCla.url) {
+                        $scope.selected.gist = undefined;
+                    }
+                };
+
+                clearDropdown(item);
+                clearGistSelection(item);
+            };
+
+            $scope.$watch('selected.item', function (newValue, oldValue) {
+                handleNullCla(newValue);
+            });
+
+            $scope.isComplete = function () {
+                return $scope.selected.item && (($scope.isRepo($scope.selected.item) && (!$scope.selected.gist.url || $scope.isValid($scope.selected.gist.url))) || (!$scope.isRepo($scope.selected.item) && $scope.isValid($scope.selected.gist.url)));
+            };
         }
     ])
     .directive('feature', ['$window', function () {

--- a/src/client/controller/settings.js
+++ b/src/client/controller/settings.js
@@ -142,6 +142,9 @@ module.controller('SettingsCtrl', ['$rootScope', '$scope', '$stateParams', '$HUB
         };
 
         $scope.getGistName = function() {
+            if (!$scope.item.gist) {
+                return '';
+            }
             $scope.gist.fileName = $scope.gist.fileName ? $scope.gist.fileName : utils.getGistAttribute($scope.gist, 'filename');
             return $scope.gist.fileName;
         };
@@ -172,7 +175,7 @@ module.controller('SettingsCtrl', ['$rootScope', '$scope', '$stateParams', '$HUB
         };
 
         $scope.isLinkActive = function() {
-            return !$scope.loading && $scope.valid.gist && $scope.valid.webhook;
+            return (!$scope.loading && $scope.valid.gist && $scope.valid.webhook) || !$scope.item.gist;
         };
 
         $scope.renderHtml = function(html_code) {

--- a/src/client/templates/home.html
+++ b/src/client/templates/home.html
@@ -2,47 +2,20 @@
 <div id="activated_cla" ng-show="user.value.admin" class="row content-block">
 
 	<div class="row" style="margin-bottom: 65px; margin-top: 15px; padding-left:0px" ng-hide="newLink">
-		<button class="btn btn-info" ng-click="newLink = !newLink" ng-init="newLink=false" style="font-size: 18px; font-weight: 200">Create new link</button>
+		<button class="btn btn-info" ng-click="newLink = !newLink" ng-init="newLink=false" style="font-size: 18px; font-weight: 200">Configure CLA</button>
 	</div>
 	<div class="row" ng-show="newLink">
-		<h4 class="col-xs-12" style="margin: 25px 0; padding-left: 0;">Create new link</h4>
+		<h4 class="col-xs-12" style="margin: 25px 0; padding-left: 0;">Configure CLA</h4>
 	</div>
 
 	<div class="well row" ng-show="newLink" style="max-width:400px; position:relative;">
 		<div ng-click="newLink = !newLink" class="fa fa-times close-button" style="position:absolute; right:20px"></div>
-
-		<h5 class="link-topic-1">
-			<span class="link-topic-number">1</span>&nbsp;Choose a CLA
-		</h5>
-		<div class="col-xs-12">
-			<div style="margin-bottom: 5px;">Select from Gist &nbsp;
-				<span class="clickable" ng-click="info()" style="font-size:12px; text-decoration:underline">(don't have one?)</span>
-			</div>
-			<div class="form-group has-feedback" style="margin-bottom: 10px;">
-				<ui-select ng-model="selected.gist" theme="selectize">
-					<ui-select-match placeholder="select" allow-clear="true">
-						<button class="fa fa-times clear-button" ng-click="clear($event, 'gist')" ng-show="$select.selected.name"></button> {{$select.selected.name}}
-
-					</ui-select-match>
-					<ui-select-choices group-by="groupDefaultCla" repeat="gist in gists | filter: $select.search" null-option="emptyGist">
-						<span ng-bind-html="gist.name | highlight: $select.search"></span>
-					</ui-select-choices>
-				</ui-select>
-			</div>
-			<div style="margin-bottom:10px">- or -</div>
-			<div style="margin-bottom: 5px;">Paste a URL from a Gist</div>
-			<input ng-disabled="selected.gist.name" class="form-control" ng-model="selected.gist.url" placeholder="https://gist.github.com/<your cla gist id>" required></input>
-			<div style="margin-top: 15px;">
-				<input type="checkbox" ng-model="selected.sharedGist" ng-init="selected.sharedGist = false">&nbsp;Share the gist with multiple repos or orgs</input>
-  		</div>
-		</div>
-
 		<h5 ng-if="!user.value.org_admin" class="col-xs-12 link-topic-2">
-			<span class="link-topic-number">2</span>&nbsp;Choose a repository
-            <span class="clickable" ng-click="addScope()" style="font-size:12px; text-decoration:underline">(want to link an org?)</span>
+			<span class="link-topic-number">1</span>&nbsp;Choose a repository
+      <span class="clickable" ng-click="addScope()" style="font-size:12px; text-decoration:underline">(want to link an org?)</span>
 		</h5>
 		<h5 ng-if="user.value.org_admin" class="col-xs-12 link-topic-2">
-			<span class="link-topic-number">2</span>&nbsp;Choose an org or a repo
+			<span class="link-topic-number">1</span>&nbsp;Choose an org or a repo
 		</h5>
 		<div class="col-xs-12">
 			<div></div>
@@ -63,13 +36,39 @@
 				</span>
 			</div>
 		</div>
+		<h5 class="link-topic-1">
+			<span class="link-topic-number">2</span>&nbsp;Choose a CLA
+		</h5>
+		<div class="col-xs-12">
+			<div style="margin-bottom: 5px;">Select from Gist &nbsp;
+				<span class="clickable" ng-click="info()" style="font-size:12px; text-decoration:underline">(don't have one?)</span>
+			</div>
+			<div class="form-group has-feedback" style="margin-bottom: 10px;">
+				<ui-select ng-model="selected.gist" theme="selectize">
+					<ui-select-match placeholder="select" allow-clear="true">
+						<button class="fa fa-times clear-button" ng-click="clear($event, 'gist')" ng-show="$select.selected.name"></button> {{$select.selected.name}}
+
+					</ui-select-match>
+					<ui-select-choices group-by="groupDefaultCla" repeat="gist in gists | filter: $select.search" null-option="emptyGist">
+						<span ng-bind-html="gist.name | highlight: $select.search"></span>
+					</ui-select-choices>
+				</ui-select>
+			</div>
+			<div style="margin-bottom:10px">- or -</div>
+			<div style="margin-bottom: 5px;">Paste a URL from a Gist</div>
+			<input ng-disabled="selected.gist.name" class="form-control" ng-model="selected.gist.url" placeholder="https://gist.github.com/<your cla gist id>" required></input>
+			<div style="margin-top: 15px;">
+				<input type="checkbox" ng-model="selected.sharedGist" ng-init="selected.sharedGist = false" ng-disabled="selected.gist && !selected.gist.url">&nbsp;Share the gist with multiple repos or orgs</input>
+			</div>
+		</div>
+
 		<div ng-repeat="error in errorMsg" class="alert alert-danger col-xs-12" role="alert" ng-show="errorMsg.length > 0">
 			<span class="fa fa-warning" aria-hidden="true"></span>
 			<span class="sr-only">Error:</span> {{ error }}
 		</div>
 	</div>
 	<div class="row" style="max-width:400px; position:relative; margin-bottom: 65px;" ng-show="newLink">
-		<button class="btn btn-info col-xs-12" ng-click="linkCla()" ng-disabled="!selected.item || !isValid(selected.gist.url)" style="height: 45px">
+		<button class="btn btn-info col-xs-12" ng-click="linkCla()" ng-disabled="!isComplete()" style="height: 45px">
 			<img src="/assets/images/link_button.svg" style="height: 18px">
 			LINK
 		</button>

--- a/src/client/templates/settings.html
+++ b/src/client/templates/settings.html
@@ -12,39 +12,45 @@
     </div>
 
     <div class="col-xs-12 col-sm-3 col-lg-2">
-        <div ng-if="!loading && gist.id.length > 0" class="text">
-            <a ng-href="{{gist.html_url}}" target="space">{{getGistName()}}</a>
+        <div>
+            <a ng-if="!loading && gist.id.length > 0" ng-href="{{gist.html_url}}" target="space">{{getGistName()}}</a>
+            <span ng-if="!item.gist">Disabled</span>
         </div>
     </div>
 
     <div class="col-xs-12 col-lg-2 hidden-xs hidden-sm hidden-md text">
-        <a ng-href="{{gist.html_url}}" target="space">{{gist.html_url}}</a>
+        <a ng-if="item.gist" ng-href="{{gist.html_url}}" target="space">{{gist.html_url}}</a>
     </div>
 
     <div class="col-xs-12 col-sm-2 col-lg-2 text">
-        {{gist.updated_at | date:'longDate'}}
+        <span ng-if="item.gist">{{gist.updated_at | date:'longDate'}}</span>
     </div>
 
     <div class="col-xs-12 col-sm-1 col-lg-1 text">
-        {{ item.sharedGist ? 'Yes' : 'No' }}
+        <span ng-if="item.gist">{{ item.sharedGist ? 'Yes' : 'No' }}</span>
     </div>
 
-    <div class="col-xs-4 col-sm-1 col-lg-1" style="text-align:center; text-decoration: underline;">
-        <a ng-click="getReport(item);" class="clickable">{{signatures.value.length}}</a>
+    <div class="col-xs-4 col-sm-1 col-lg-1" style="text-align:center">
+        <a ng-if="item.gist" ng-click="getReport(item);" class="clickable" style="text-decoration: underline;">{{signatures.value.length}}</a>
     </div>
 
     <script type="text/ng-template" id="validateLink.html">
-        <i class="fa" ng-class="valid.gist ? 'fa-check' : 'fa-times'" style="white-space: nowrap;"> gist</i>
-        <i class="fa" ng-class="valid.webhook ? 'fa-check' : 'fa-times'" style="white-space: nowrap;"> webhook</i>
+        <div ng-if="item.gist">
+            <i class="fa" ng-class="valid.gist ? 'fa-check' : 'fa-times'" style="white-space: nowrap;"> gist</i>
+            <i class="fa" ng-class="valid.webhook ? 'fa-check' : 'fa-times'" style="white-space: nowrap;"> webhook</i>
+        </div>
+        <div ng-if="!item.gist">
+            <i class="fa fa-check" style="white-space: nowrap;"> disabled</i>
+        </div>
     </script>
     <div class="col-xs-4 col-sm-1 col-lg-1 center-block">
         <img ng-src="/assets/images/{{isLinkActive() ? 'link_active.svg' : 'link_inactive.svg'}}" popover-placement="right" popover-template="'validateLink.html'" popover-trigger="mouseenter" popover-popup-delay="300">
     </div>
 
     <script type="text/ng-template" id="moreActions.html">
-        <button class="btn btn-info" ng-click="upload(item)">Import</button>
+        <button class="btn btn-info" ng-click="upload(item)" ng-if='item.gist'>Import</button>
         <button class="btn btn-info" ng-click="recheck(item)">Recheck PRs</button>
-        <button class="btn btn-info" ng-click="getBadge(item)" ng-show="item.repo">Get Badge</button>
+        <button class="btn btn-info" ng-click="getBadge(item)" ng-show="item.repo && item.gist">Get Badge</button>
     </script>
     <div class="col-xs-4 col-sm-1 action" ng-init="popoverIsOpen=false" ng-show="(item.org && user.value.org_admin) || item.repo">
         <i class="fa fa-ellipsis-h action-icon" tooltip-placement="bottom" tooltip="More..."

--- a/src/server/api/webhook.js
+++ b/src/server/api/webhook.js
@@ -2,53 +2,33 @@
 var github = require('../services/github');
 var repoService = require('../services/repo');
 var url = require('../services/url');
+var async = require('async');
 
-function createRepoHook(req, done) {
-    github.call({
-        obj: 'repos',
-        fun: 'createHook',
-        arg: {
-            owner: req.args.owner,
-            repo: req.args.repo,
-            name: 'web',
-            config: { url: url.webhook(req.args.repo), content_type: 'json' },
-            events: ['pull_request'],
-            active: true
-        },
-        noCache: true,
-        token: req.user.token
-    }, done);
-}
-
-function updateRepoHook(owner, repo, id, active, token, done) {
-    github.call({
-        obj: 'repos',
-        fun: 'editHook',
-        arg: {
-            owner: owner,
-            repo: repo,
-            name: 'web',
-            config: { url: url.webhook(repo), content_type: 'json' },
-            id: id,
-            active: active
-        },
-        noCache: true,
-        token: token
-    }, done);
-}
-
-function getHook(obj, arg, token, done) {
-    github.call({
-        obj: obj,
+function getHook(owner, repo, noCache, token, done) {
+    if (!owner || !token) {
+        return done('Owner/org and token is required.');
+    }
+    var args = {
         fun: 'getHooks',
-        arg: arg,
+        arg: {
+            noCache: noCache
+        },
         token: token
-    }, function callback(err, hooks) {
+    };
+    if (repo) {
+        args.obj = 'repos';
+        args.arg.owner = owner;
+        args.arg.repo = repo;
+    } else {
+        args.obj = 'orgs';
+        args.arg.org = owner;
+    }
+    github.call(args, function callback(err, hooks) {
         var hook = null;
 
         if (!err && hooks && hooks.length > 0) {
             hooks.forEach(function(webhook) {
-                if (webhook.config.url && webhook.config.url.indexOf(url.baseWebhook) > -1) {
+                if (webhook.active && webhook.config.url && webhook.config.url.indexOf(url.baseWebhook) > -1) {
                     hook = webhook;
                 }
             });
@@ -60,61 +40,152 @@ function getHook(obj, arg, token, done) {
     });
 }
 
-function deactevateRepoHook(owner, repo, token, done) {
-    getHook('repos', {
-        owner: owner,
-        repo: repo
-    }, token, function(err, hook) {
-        if (hook && hook.id) {
-            updateRepoHook(owner, repo, hook.id, false, token, done);
+function getRepoHook(owner, repo, noCache, token, done) {
+    getHook(owner, repo, noCache, token, function (error, hook) {
+        if (error || hook) {
+            return done(error, hook);
         }
-    });
-}
-
-function createOrgHook(req, done) {
-    var org = req.args.org;
-    var args = {
-        obj: 'orgs',
-        fun: 'createHook',
-        arg: {
-            org: org,
-            name: 'web',
-            config: { url: url.webhook(org), content_type: 'json' },
-            events: ['pull_request'],
-            noCache: true,
-            active: true
-        },
-        token: req.user.token
-    };
-    github.call(args, function(err, data) {
-        done(err, data);
-        repoService.getByOwner(org, function(err, repos) {
-            if (repos && repos.length > 0) {
-                repos.forEach(function(repo) {
-                    deactevateRepoHook(org, repo.repo, repo.token, function() {});
-                });
+        getHook(owner, undefined, noCache, token, function (error, hook) {
+            if (error && error.code !== 404) {
+                // When the owner is not an org, github returns 404.
+                return done(error);
             }
+            return done(null, hook);
         });
     });
 }
 
-function extractGithubArgs(args) {
-    var obj = args.org ? 'orgs' : 'repos';
-    var arg = args.org ? {
-        org: args.org
-    } : {
-        owner: args.owner,
-        repo: args.repo
+function getOrgHook(org, noCache, token, done) {
+    getHook(org, undefined, noCache, token, done);
+}
+
+function createHook(owner, repo, token, done) {
+    if (!owner || !token) {
+        return done('Owner/org and token is required.');
+    }
+    var args = {
+        fun: 'createHook',
+        arg: {
+            noCache: true,
+            config: { content_type: 'json' },
+            name: 'web',
+            events: ['pull_request'],
+            active: true
+        },
+        token: token
     };
-    return { obj: obj, arg: arg };
+    if (repo) {
+        args.obj = 'repos';
+        args.arg.repo = repo;
+        args.arg.owner = owner;
+        args.arg.config.url = url.webhook(repo);
+    } else {
+        args.obj = 'orgs';
+        args.arg.org = owner;
+        args.arg.config.url = url.webhook(owner);
+    }
+    github.call(args, done);
+}
+
+function createRepoHook(owner, repo, token, done) {
+    getRepoHook(owner, repo, true, token, function (error, hook) {
+        if (error || hook) {
+            return done(error, hook);
+        }
+        createHook(owner, repo, token, done);
+    });
+}
+
+function createOrgHook(org, token, done) {
+    getOrgHook(org, true, token, function (error, hook) {
+        if (error || hook) {
+            return done(error || 'Webhook already exist with base url ' + url.baseWebhook);
+        }
+        createHook(org, undefined, token, function (err, hook) {
+            if (err) {
+                return done(err, null);
+            }
+            handleHookForLinkedRepoInOrg(org, token, removeRepoHook, function (e) {
+                done(e, hook);
+            });
+        });
+    });
+}
+
+function removeHook(owner, repo, hookId, token, done) {
+    if (!owner || !token) {
+        return done('Owner/org and token is required.');
+    }
+    var args = {
+        fun: 'deleteHook',
+        arg: {
+            id: hookId,
+            noCache: true
+        },
+        token: token
+    };
+    if (repo) {
+        args.obj = 'repos';
+        args.arg.owner = owner;
+        args.arg.repo = repo;
+    } else {
+        args.obj = 'orgs';
+        args.arg.org = owner;
+    }
+    github.call(args, done);
+}
+
+function removeRepoHook(owner, repo, token, done) {
+    getRepoHook(owner, repo, true, token, function (err, hook) {
+        if (err || !hook) {
+            return done(err || 'No webhook found with base url ' + url.baseWebhook);
+        }
+        if (hook.type === 'Organization') {
+            return done(null, null);
+        }
+        removeHook(owner, repo, hook.id, token, done);
+    });
+}
+
+function removeOrgHook(org, token, done) {
+    getOrgHook(org, true, token, function (error, hook) {
+        if (error || !hook) {
+            return done(error || 'No webhook found with base url ' + url.baseWebhook);
+        }
+        removeHook(org, undefined, hook.id, token, function (err, result) {
+            if (err) {
+                return done(err, null);
+            }
+            handleHookForLinkedRepoInOrg(org, token, createRepoHook, function (e) {
+                done(e, hook);
+            });
+        });
+    });
+}
+
+function handleHookForLinkedRepoInOrg(org, token, delegateFun, done) {
+    repoService.getByOwner(org, function (error, repos) {
+        if (error || !repos || repos.length === 0) {
+            return done(error, result);
+        }
+        async.series(repos.map(function (repo) {
+            return function (callback) {
+                if (!repo.gist) {
+                    // Repos with Null CLA will NOT have webhook
+                    return callback(null, null);
+                }
+                delegateFun(repo.owner, repo.repo, token, callback);
+            };
+        }), function (err, results) {
+            done(err);
+        });
+    });
 }
 
 module.exports = {
 
-    get: function(req, done) {
-        var githubArgs = extractGithubArgs(req.args);
-
-        getHook(githubArgs.obj, githubArgs.arg, req.user.token, done);
+    get: function (req, done) {
+        return req.args && req.args.org ? getOrgHook(req.args.org, req.args.noCache, req.user.token, done) : getRepoHook(req.args.owner, req.args.repo, req.args.noCache, req.user.token, done);
 
         // now we will have to check two things:
         // 1) webhook user still has push access to this repo
@@ -127,26 +198,10 @@ module.exports = {
     },
 
     create: function(req, done) {
-        return req.args && req.args.orgId ? createOrgHook(req, done) : createRepoHook(req, done);
+        return req.args && req.args.orgId ? createOrgHook(req.args.org, req.user.token, done) : createRepoHook(req.args.owner, req.args.repo, req.user.token, done);
     },
 
-    remove: function(req, done) {
-        this.get(req, function(err, hook) {
-            if (err || !hook) {
-                done(err || 'No webhook found with base url ' + url.baseWebhook);
-                return;
-            }
-            var githubArgs = extractGithubArgs(req.args);
-            githubArgs.arg.id = hook.id;
-            githubArgs.arg.noCache = true;
-
-            github.call({
-                obj: githubArgs.obj,
-                fun: 'deleteHook',
-                arg: githubArgs.arg,
-                token: req.user.token
-            }, done);
-        });
-
+    remove: function (req, done) {
+        return req.args && req.args.org ? removeOrgHook(req.args.org, req.user.token, done) : removeRepoHook(req.args.owner, req.args.repo, req.user.token, done);
     }
 };

--- a/src/server/services/pullRequest.js
+++ b/src/server/services/pullRequest.js
@@ -158,5 +158,40 @@ module.exports = {
         if (typeof done === 'function') {
             done();
         }
+    },
+
+    deleteComment: function (args, done) {
+        this.getComment({
+            repo: args.repo,
+            owner: args.owner,
+            number: args.number
+        }, function (error, comment) {
+            if (error) {
+                return log.warn(error, 'with args:', args.repo, args.owner, args.number);
+            }
+            if (!comment) {
+                return;
+            }
+            github.call({
+                obj: 'issues',
+                fun: 'deleteComment',
+                arg: {
+                    owner: args.owner,
+                    repo: args.repo,
+                    id: comment.id
+                },
+                basicAuth: {
+                    user: config.server.github.user,
+                    pass: config.server.github.pass
+                }
+            }, function (error) {
+                if (error) {
+                    log.warn(error, 'with args:', args, 'and commentId: ', comment.id);
+                }
+            });
+        });
+        if (typeof done === 'function') {
+            done();
+        }
     }
 };

--- a/src/server/services/repo.js
+++ b/src/server/services/repo.js
@@ -282,19 +282,18 @@ module.exports = {
 
         };
 
-        orgService.get({
-            orgId: args.orgId
-        }, function (e, org) {
-            if (!org) {
-                self.get(args, function (e, repo) {
-                    if (e || !repo) {
-                        handleError(e, args);
-                        return;
+        self.get(args, function (error, repo) {
+            if (!repo) {
+                orgService.get({
+                    orgId: args.orgId
+                }, function (err, org) {
+                    if (err || !org) {
+                        return handleError(err || error, args);
                     }
-                    collectTokenAndCallGithub(args, repo);
+                    collectTokenAndCallGithub(args, org);
                 });
             } else {
-                collectTokenAndCallGithub(args, org);
+                collectTokenAndCallGithub(args, repo);
             }
         });
     },

--- a/src/server/webhooks/pull_request.js
+++ b/src/server/webhooks/pull_request.js
@@ -59,26 +59,29 @@ module.exports = function (req, res) {
 
 
         setTimeout(function () {
-            orgService.get({
-                orgId: args.orgId
-            }, function (err, org) {
-                if (org) {
-                    args.token = org.token;
-                    args.gist = org.gist; //TODO: Test it!!
-                    if (!org.isRepoExcluded(args.repo)) {
-                        repoService.getGHRepo(args, function (err, repo) {
-                            if (repo) {
-                                handleWebHook(args);
-                            }
-                        });
+            repoService.get(args, function (e, repo) {
+                if (repo) {
+                    if (!repo.gist) {
+                        return;
                     }
-                } else {
                     args.orgId = undefined;
-                    repoService.get(args, function (e, repo) {
-                        if (repo) {
-                            args.token = repo.token;
-                            args.gist = repo.gist; //TODO: Test it!!
-                            handleWebHook(args);
+                    args.token = repo.token;
+                    args.gist = repo.gist; //TODO: Test it!!
+                    handleWebHook(args);
+                } else {
+                    orgService.get({
+                        orgId: args.orgId
+                    }, function (err, org) {
+                        if (org) {
+                            args.token = org.token;
+                            args.gist = org.gist; //TODO: Test it!!
+                            if (!org.isRepoExcluded(args.repo)) {
+                                repoService.getGHRepo(args, function (err, repo) {
+                                    if (repo) {
+                                        handleWebHook(args);
+                                    }
+                                });
+                            }
                         }
                     });
                 }

--- a/src/tests/server/api/webhook.js
+++ b/src/tests/server/api/webhook.js
@@ -16,37 +16,50 @@ var webhook_api = require('../../../server/api/webhook');
 
 var testData = require('../testData').data;
 
-describe('webhookApi', function() {
-    var resGetHooks;
+describe('webhookApi', function () {
+    var hook;
+    var repo;
+    var resGetRepoHooks;
+    var resGetOrgHooks;
     beforeEach(function() {
-        resGetHooks = [{
+        hook = {
             id: 123,
+            active: true,
             config: {
                 url: url.baseWebhook
             }
-        }];
+        };
+        repo = {
+            id: 123,
+            repo: 'myRepo',
+            owner: 'login',
+            gist: 'https://gist.github.com/myRepo/gistId'
+        };
+        resGetRepoHooks = [hook];
+        resGetOrgHooks = [hook];
         sinon.stub(github, 'call', function(args, done) {
             if (args.fun === 'getHooks') {
-                done(null, resGetHooks);
+                args.obj === 'repos' ? done(null, resGetRepoHooks) :  done(null, resGetOrgHooks);
+            } else if (args.fun === 'deleteHook') {
+                done(null, hook);
+            } else if (args.fun === 'createHook') {
+                done(null, hook);
             } else {
                 done();
             }
         });
-        sinon.stub(Repo, 'findOne', function(args, done) {
-            var repo = {
-                repo: 'myRepo',
-                owner: 'login',
-                gist: 'https://gist.github.com/myRepo/gistId'
-            };
-            done(null, repo);
+        sinon.stub(Repo, 'find', function (args, done) {
+            done(null, [repo]);
         });
     });
     afterEach(function() {
         github.call.restore();
-        Repo.findOne.restore();
+        Repo.find.restore();
     });
     describe('webhook:create', function() {
-        it('should call github service with user token', function(it_done) {
+        it('should create a repo webhook when both repo and org webhook does NOT exist', function(it_done) {
+            resGetRepoHooks = [];
+            resGetOrgHooks = [];
             var expArgs = {
                 obj: 'repos',
                 fun: 'createHook',
@@ -82,7 +95,81 @@ describe('webhookApi', function() {
             });
         });
 
-        it('should create a webhook for an organisation', function(it_done) {
+        it('should NOT create a repo webhook when repo webhook exists', function(it_done) {
+            var expArgs = {
+                obj: 'repos',
+                fun: 'createHook',
+                arg: {
+                    owner: 'login',
+                    repo: 'myRepo',
+                    name: 'web',
+                    config: {
+                        url: url.webhook('myRepo'),
+                        content_type: 'json'
+                    },
+                    events: ['pull_request'],
+                    active: true
+                },
+                token: 'abc'
+            };
+
+            var req = {
+                user: {
+                    id: 1,
+                    login: 'login',
+                    token: 'abc'
+                },
+                args: {
+                    repo: 'myRepo',
+                    owner: 'login'
+                }
+            };
+
+            webhook_api.create(req, function() {
+                assert(github.call.calledWithMatch(expArgs) === false);
+                it_done();
+            });
+        });
+
+        it('should NOT create a repo webhook when corresponding org webhook exists', function (it_done) {
+            resGetRepoHooks = [];
+            var expArgs = {
+                obj: 'repos',
+                fun: 'createHook',
+                arg: {
+                    owner: 'login',
+                    repo: 'myRepo',
+                    name: 'web',
+                    config: {
+                        url: url.webhook('myRepo'),
+                        content_type: 'json'
+                    },
+                    events: ['pull_request'],
+                    active: true
+                },
+                token: 'abc'
+            };
+
+            var req = {
+                user: {
+                    id: 1,
+                    login: 'login',
+                    token: 'abc'
+                },
+                args: {
+                    repo: 'myRepo',
+                    owner: 'login'
+                }
+            };
+
+            webhook_api.create(req, function() {
+                assert(github.call.calledWithMatch(expArgs) === false);
+                it_done();
+            });
+        });
+
+        it('should create a webhook for an organization when org webhook does NOT exist', function (it_done) {
+            resGetOrgHooks = [];
             var expArgs = {
                 obj: 'orgs',
                 fun: 'createHook',
@@ -116,20 +203,86 @@ describe('webhookApi', function() {
                 it_done();
             });
         });
+
+        it('should remove repo webhook after creating an org webhook', function (it_done) {
+            resGetOrgHooks = [];
+            hook.type = 'Repository';
+            var expArgs = {
+                obj: 'repos',
+                fun: 'deleteHook',
+                arg: {
+                    id: 123,
+                    repo: 'myRepo',
+                    owner: 'login',
+                    noCache: true
+                },
+                token: 'abc'
+            };
+
+            var req = {
+                user: {
+                    id: 1,
+                    login: 'login',
+                    token: 'abc'
+                },
+                args: {
+                    org: testData.orgs[0].login,
+                    orgId: testData.orgs[0].id
+                }
+            };
+
+            webhook_api.create(req, function() {
+                assert(github.call.calledWithMatch(expArgs));
+                it_done();
+            });
+        });
+
+        it('should NOT remove a webhook for a repo with NULL CLA after creating an org webhook', function (it_done) {
+            repo.gist = null;
+            var expArgs = {
+                obj: 'repos',
+                fun: 'deleteHook',
+                arg: {
+                    id: 123,
+                    repo: 'myRepo',
+                    owner: 'login',
+                    noCache: true
+                },
+                token: 'abc'
+            };
+
+            var req = {
+                user: {
+                    id: 1,
+                    login: 'login',
+                    token: 'abc'
+                },
+                args: {
+                    org: testData.orgs[0].login,
+                    orgId: testData.orgs[0].id
+                }
+            };
+
+            webhook_api.create(req, function() {
+                assert(!github.call.calledWithMatch(expArgs));
+                it_done();
+            });
+        });
     });
 
-    describe('webhook:get', function() {
+    describe('webhook:get', function () {
         it('should call github service with user token for repo hooks', function(it_done) {
             var expArgs = {
                 obj: 'repos',
                 fun: 'getHooks',
                 arg: {
-                    user: 'owner',
+                    owner: 'owner',
                     repo: 'myRepo'
                 },
                 token: 'abc'
             };
-            resGetHooks = [{
+            resGetRepoHooks = [{
+                active: true,
                 config: {
                     url: url.webhook('myRepo'),
                     content_type: 'json'
@@ -144,13 +297,42 @@ describe('webhookApi', function() {
                 },
                 args: {
                     repo: 'myRepo',
-                    user: 'owner'
+                    owner: 'owner'
                 }
             };
 
-            webhook_api.get(req, function(err, hooks) {
+            webhook_api.get(req, function (err, hooks) {
                 assert(hooks);
-                github.call.calledWithMatch(expArgs);
+                assert(github.call.calledWithMatch(expArgs));
+                it_done();
+            });
+        });
+
+        it('should call github service with user token for org hooks when repo hook does NOT exist', function(it_done) {
+            resGetRepoHooks = [];
+            var expArgs = {
+                obj: 'orgs',
+                fun: 'getHooks',
+                arg: {
+                    org: 'owner'
+                },
+                token: 'abc'
+            };
+
+            var req = {
+                user: {
+                    id: 1,
+                    login: 'login',
+                    token: 'abc'
+                },
+                args: {
+                    repo: 'myRepo',
+                    owner: 'owner'
+                }
+            };
+
+            webhook_api.get(req, function (err, hooks) {
+                assert(github.call.calledWithMatch(expArgs));
                 it_done();
             });
         });
@@ -164,7 +346,8 @@ describe('webhookApi', function() {
                 },
                 token: 'abc'
             };
-            resGetHooks = [{
+            resGetOrgHooks = [{
+                active: true,
                 config: {
                     url: url.webhook(testData.orgs[0].login),
                     content_type: 'json'
@@ -184,14 +367,15 @@ describe('webhookApi', function() {
 
             webhook_api.get(req, function(err, hooks) {
                 assert(hooks);
-                github.call.calledWithMatch(expArgs);
+                assert(github.call.calledWithMatch(expArgs));
                 it_done();
             });
         });
     });
 
     describe('webhook:remove', function() {
-        it('should call github service with user token for REPO hook', function(it_done) {
+        it('should remove repo hook when it exists', function (it_done) {
+            hook.type = 'Repository';
             var expArgs = {
                 obj: 'repos',
                 fun: 'deleteHook',
@@ -221,7 +405,7 @@ describe('webhookApi', function() {
             });
         });
 
-        it('should call github service with user token for ORG hook', function(it_done) {
+        it('should remove org hook when it exists', function(it_done) {
             var expArgs = {
                 obj: 'orgs',
                 fun: 'deleteHook',
@@ -249,9 +433,54 @@ describe('webhookApi', function() {
             });
         });
 
-        it('should report error if could not delete hook', function(it_done) {
-            resGetHooks = [{
+        it('should NOT create hook for repo with NULL CLA after removing org hook', function (it_done) {
+            resGetRepoHooks = [];
+            repo.gist = null;
+            var expArgs = {
+                obj: 'repos',
+                fun: 'createHook',
+                arg: {
+                    owner: 'login',
+                    repo: 'myRepo',
+                    name: 'web',
+                    config: {
+                        url: url.webhook('myRepo'),
+                        content_type: 'json'
+                    },
+                    events: ['pull_request'],
+                    active: true
+                },
+                token: 'abc'
+            };
+
+            var req = {
+                user: {
+                    id: 1,
+                    login: 'login',
+                    token: 'abc'
+                },
+                args: {
+                    org: 'octocat'
+                }
+            };
+
+            webhook_api.remove(req, function() {
+                assert(github.call.calledWithMatch(expArgs) === false);
+                it_done();
+            });
+        });
+
+        it('should report error if could not delete repo hook', function(it_done) {
+            resGetRepoHooks = [{
                 id: 123,
+                active: true,
+                config: {
+                    url: 'any other url'
+                }
+            }];
+            resGetOrgHooks = [{
+                id: 321,
+                active: true,
                 config: {
                     url: 'any other url'
                 }
@@ -271,7 +500,6 @@ describe('webhookApi', function() {
 
             webhook_api.remove(req, function(error) {
                 assert.equal(error, 'No webhook found with base url ' + url.baseWebhook);
-
                 it_done();
             });
         });

--- a/src/tests/server/services/pullRequest.js
+++ b/src/tests/server/services/pullRequest.js
@@ -466,3 +466,66 @@ describe('pullRequest:editComment', function() {
         pullRequest.editComment(args);
     });
 });
+
+describe('pullRequest:deleteComment', function () {
+    var args = null,
+        error = null,
+        res = null;
+
+    beforeEach(function () {
+        args = {
+            repo: 'Hello-World',
+            owner: 'owner',
+            number: 1
+        };
+        error = {};
+        res = {};
+        sinon.stub(github, 'call', function(args, cb) {
+            if (args.obj === 'issues' && args.fun === 'getComments') {
+                cb(error.getComments, res.getComments);
+            }
+            if (args.obj === 'issues' && args.fun === 'deleteComment') {
+                cb(error.deleteComment, null);
+            }
+        });
+    });
+
+    afterEach(function () {
+        github.call.restore();
+    });
+
+    it('should NOT delete comment if cannot find the comment', function (it_done) {
+        res.getComments = {
+            message: 'Cannot find the comment'
+        };
+        pullRequest.deleteComment(args, function () {
+            assert(!github.call.calledWithMatch({
+                obj: 'issues',
+                fun: 'deleteComment'
+            }));
+            it_done();
+        });
+    });
+
+    it('should NOT delete comment if get commit failed', function (it_done) {
+        error.getComments = 'Get commit failed';
+        pullRequest.deleteComment(args, function () {
+            assert(!github.call.calledWithMatch({
+                obj: 'issues',
+                fun: 'deleteComment'
+            }));
+            it_done();
+        });
+    });
+
+    it('should delete comment', function (it_done) {
+        res.getComments = testDataComments_withCLAComment;
+        pullRequest.deleteComment(args, function () {
+            assert(github.call.calledWithMatch({
+                obj: 'issues',
+                fun: 'deleteComment'
+            }));
+            it_done();
+        });
+    });
+});

--- a/src/tests/server/services/repo.js
+++ b/src/tests/server/services/repo.js
@@ -487,7 +487,7 @@ describe('repo:getPRCommitters', function () {
             assert.equal(orgService.get.calledWith({
                 orgId: 1
             }), true);
-            assert.equal(Repo.findOne.called, false);
+            assert(Repo.findOne.called);
             assert(github.call.calledWithMatch({
                 obj: 'pullRequests',
                 fun: 'getCommits'

--- a/src/tests/server/services/status.js
+++ b/src/tests/server/services/status.js
@@ -277,7 +277,7 @@ var testStatusesFailure = [
     }
 ];
 
-describe('status:update', function () {
+describe('status', function () {
     var githubCallPRGet, githubCallStatusGet, assertFunction;
     beforeEach(function () {
         githubCallPRGet = {
@@ -310,165 +310,225 @@ describe('status:update', function () {
         github.call.restore();
     });
 
-    it('should create comment with admin token', function (it_done) {
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: true,
-            token: 'abc'
-        };
+    describe('update', function () {
+        it('should create comment with admin token', function (it_done) {
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: true,
+                token: 'abc'
+            };
 
-        status.update(args, function () {
-            assert.equal(github.call.callCount, 4);
-            it_done();
-        });
-    });
-
-    it('should create status pending if not signed', function (it_done) {
-        assertFunction = function (args) {
-            assert.equal(args.arg.state, 'pending');
-            assert.equal(args.arg.context, 'license/cla');
-
-        };
-        githubCallStatusGet.data = testStatusesSuccess;
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: false,
-            token: 'abc'
-        };
-
-        status.update(args, function () {
-            assert(github.call.calledThrice);
-            it_done();
-        });
-    });
-
-    it('should not update status if no pull request found', function (it_done) {
-        githubCallPRGet.err = 'error';
-        githubCallPRGet.data = null;
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: false,
-            token: 'abc'
-        };
-
-        status.update(args);
-
-        assert(github.call.calledOnce);
-        it_done();
-    });
-
-    it('should not update status if no pull request found', function (it_done) {
-        githubCallPRGet.data = {
-            message: 'Not found'
-        };
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: false,
-            token: 'abc'
-        };
-
-        status.update(args);
-
-        assert(github.call.calledOnce);
-        it_done();
-    });
-
-    it('should not load PR if sha is provided', function (it_done) {
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: true,
-            token: 'abc',
-            sha: 'sha1'
-        };
-
-        status.update(args, function () {
-            assert(github.call.calledThrice);
-            it_done();
-        });
-    });
-
-    it('should use old and new context if there is already a status with this context', function (it_done) {
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: true,
-            token: 'abc',
-            sha: 'sha1'
-        };
-        // assertFunction = function (args) {
-        //     assert.equal(args.arg.context, 'licence/cla');
-        // };
-
-        status.update(args, function () {
-            assert(github.call.calledThrice);
-            it_done();
+            status.update(args, function () {
+                assert.equal(github.call.callCount, 4);
+                it_done();
+            });
         });
 
-    });
+        it('should create status pending if not signed', function (it_done) {
+            assertFunction = function (args) {
+                assert.equal(args.arg.state, 'pending');
+                assert.equal(args.arg.context, 'license/cla');
 
-    it('should not update status if it has not changed', function (it_done) {
-        githubCallStatusGet.data = testStatusesSuccess;
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: true,
-            token: 'abc',
-            sha: 'sha1'
-        };
+            };
+            githubCallStatusGet.data = testStatusesSuccess;
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: false,
+                token: 'abc'
+            };
 
-        status.update(args, function () {
+            status.update(args, function () {
+                assert(github.call.calledThrice);
+                it_done();
+            });
+        });
+
+        it('should not update status if no pull request found', function (it_done) {
+            githubCallPRGet.err = 'error';
+            githubCallPRGet.data = null;
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: false,
+                token: 'abc'
+            };
+
+            status.update(args);
+
             assert(github.call.calledOnce);
-            assert(github.call.calledWithMatch({ obj: 'repos', fun: 'getStatuses' }));
             it_done();
         });
 
+        it('should not update status if no pull request found', function (it_done) {
+            githubCallPRGet.data = {
+                message: 'Not found'
+            };
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: false,
+                token: 'abc'
+            };
+
+            status.update(args);
+
+            assert(github.call.calledOnce);
+            it_done();
+        });
+
+        it('should not load PR if sha is provided', function (it_done) {
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: true,
+                token: 'abc',
+                sha: 'sha1'
+            };
+
+            status.update(args, function () {
+                assert(github.call.calledThrice);
+                it_done();
+            });
+        });
+
+        it('should use old and new context if there is already a status with this context', function (it_done) {
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: true,
+                token: 'abc',
+                sha: 'sha1'
+            };
+            // assertFunction = function (args) {
+            //     assert.equal(args.arg.context, 'licence/cla');
+            // };
+
+            status.update(args, function () {
+                assert(github.call.calledThrice);
+                it_done();
+            });
+
+        });
+
+        it('should not update status if it has not changed', function (it_done) {
+            githubCallStatusGet.data = testStatusesSuccess;
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: true,
+                token: 'abc',
+                sha: 'sha1'
+            };
+
+            status.update(args, function () {
+                assert(github.call.calledOnce);
+                assert(github.call.calledWithMatch({ obj: 'repos', fun: 'getStatuses' }));
+                it_done();
+            });
+
+        });
+
+        it('should update status if there are no old ones', function (it_done) {
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: false,
+                token: 'abc',
+                sha: 'sha1'
+            };
+            githubCallStatusGet.data = null;
+
+            status.update(args, function () {
+                assert(github.call.calledTwice);
+                it_done();
+            });
+
+        });
+
+        it('should update statuses of all contexts if there are both (licenCe and licenSe)', function (it_done) {
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: true,
+                token: 'abc',
+                sha: 'sha1'
+            };
+            githubCallStatusGet.data = testStatusesFailure;
+
+            status.update(args, function () {
+                assert(github.call.calledThrice);
+                it_done();
+            });
+
+        });
     });
 
-    it('should update status if there are no old ones', function (it_done) {
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: false,
-            token: 'abc',
-            sha: 'sha1'
-        };
-        githubCallStatusGet.data = null;
+    describe('delete', function () {
+        var args, expArgsGithubPullRequests;
+        beforeEach(function () {
+            args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                token: 'abc'
+            };
 
-        status.update(args, function () {
-            assert(github.call.calledTwice);
-            it_done();
+            expArgsGithubPullRequests = {
+                createStatus: {
+                    obj: 'repos',
+                    fun: 'createStatus',
+                    arg: {
+                        owner: args.owner,
+                        repo: args.repo,
+                        sha: githubCallPRGet.data.head.sha,
+                        state: 'success',
+                        description: 'No need to sign Contributor License Agreement.',
+                        target_url: undefined,
+                        context: 'license/cla',
+                        noCache: true
+                    },
+                    token: args.token
+                },
+                get: {
+                    obj: 'pullRequests',
+                    fun: 'get',
+                    arg: {
+                        owner: args.owner,
+                        repo: args.repo,
+                        number: args.number,
+                        noCache: true
+                    },
+                    token: args.token
+                }
+            };
         });
 
-    });
-
-    it('should update statuses of all contexts if there are both (licenCe and licenSe)', function (it_done) {
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: true,
-            token: 'abc',
-            sha: 'sha1'
-        };
-        githubCallStatusGet.data = testStatusesFailure;
-
-        status.update(args, function () {
-            assert(github.call.calledThrice);
-            it_done();
+        it('should delete status when sha is not provided', function (it_done) {
+            status.delete(args, function (error, done) {
+                assert(github.call.calledWith(expArgsGithubPullRequests.get));
+                assert(github.call.calledWith(expArgsGithubPullRequests.createStatus));
+                it_done();
+            });
         });
 
+        it('should delete status when sha is provided', function (it_done) {
+            args.sha = githubCallPRGet.data.head.sha;
+            status.delete(args, function (error, done) {
+                assert(!github.call.calledWith(expArgsGithubPullRequests.get));
+                assert(github.call.calledWith(expArgsGithubPullRequests.createStatus));
+                it_done();
+            });
+        });
     });
 });


### PR DESCRIPTION
1. When receiving PR 'open, reopen, synchronize' event, don't update the PR if the repo has null type CLA and the corresponding org has CLA.
2. Recheck an org's PR won't update PRs of a repo with a null type CLA.
4. People can only sign a repo CLA when it's different form org CLA.
5. Delete CLA comment and status after rechecking PRs of a repo with a null type CLA.
6. Don't allow orgs to be configured with a null type CLA.
